### PR TITLE
Chapter 1 – proof-reading and suggested spelling normalization

### DIFF
--- a/caibidlí/new-orthography/manannan00.md
+++ b/caibidlí/new-orthography/manannan00.md
@@ -3,8 +3,8 @@
 
 le ceannach díreach ó
 
-OIFIG DÍOLTA FOILLSEAChÁIN RIALTAIS, 3—4, SRÁID AN ChOLÁISTE.
-BAILE ÁThA CLIATh.
+OIFIG DÍOLTA FOILLSEACHÁIN RIALTAIS, 3—4, SRÁID AN CHOLÁISTE.
+BAILE ÁTHA CLIATH.
 
 no tré aon díoltóir leabhar.
 
@@ -12,40 +12,40 @@ no tré aon díoltóir leabhar.
 
 Máiréad Ní Ghráda
 
-OIFIG AN tSOLÁThAIR
+OIFIG AN tSOLÁTHAIR
 
 Baile Átha Cliath
 
 #    
 
-Foillsigheadh de’n chéad uair, 1940.
+Foillsíodh den chéad uair, 1940.
 
 #     
 
-Toirbhirim an leabhar so do BhRIAN
+Toirbhirim an leabhar so do BHRIAN
 mar go dtug sé cabhair agus comhairle
 dhom agus mé á scríobhadh.
 
 M. Ní Gh.
 
-Mí na Nodlag, 1939.
+Mí na Nollag, 1939.
 
 # CLÁR AN LEABhAIR
 
-|                                   |Leathanach.|
-| :---                                  | ---:|
-| Pláinéid ná Feaca Súil Duine Riamh     |   9 |
-| An Radharc tríd an gCiandracán         |  18 |
-| An Turas go Manannán                  |  31 |
-| Manannán                              |  44 |
-| Muintear Mhanannáin                    |  53 |
-| Na ‘Cráidhmí’                          |  68 |
-| An tárd-Mháighistir                     |  76 |
-| An Príosún                            |  87 |
-| Oidhche sa Choill                        |  98 |
-| An tInneall                           | 110 |
-| Oidhche thar Oidhcheanta                   | 124 |
-| ‘Lugh Lámh-fhada’                        | 137 |
-| An Troid leis na ‘Cráidhmí’            | 151 |
-| Díoghaltas                             | 166 |
-| An tÉalódh                             | 178 |
+|                                    | Leathanach. |
+| :---                               | ---:        |
+| Pláinéid ná Feaca Súil Duine Riamh | 9           |
+| An Radharc tríd an gCiandracán     | 18          |
+| An Turas go Manannán               | 31          |
+| Manannán                           | 44          |
+| Muintear Mhanannáin                | 53          |
+| Na ‘Cráidhmí’                      | 68          |
+| An tÁrd-Mháighistir                | 76          |
+| An Príosún                         | 87          |
+| Oíche sa Choill                    | 98          |
+| An tInneall                        | 110         |
+| Oíche thar Oícheanta               | 124         |
+| ‘Lugh Lámhfhada’                   | 137         |
+| An Troid leis na ‘Cráidhmí’        | 151         |
+| Díoltas                            | 166         |
+| An tÉalódh                         | 178         |

--- a/caibidlí/new-orthography/manannan01.md
+++ b/caibidlí/new-orthography/manannan01.md
@@ -6,39 +6,39 @@ Do chaith Seán Ó Maolchatha é féin siar sa chathaoir
 agus do chuir gáire as.
 “Mar mhagadh taoi,” as seisean.
 
-D’éirigh an fear eile agus do shiubhail anonn chun na
+D’éirigh an fear eile agus do shiúil anonn chun na
 teine. Do dhearg sé a phíopa agus do bhain seach as sul
 ar labhair sé.
 
-“Ní haon mhagadh é,” ar seisean, “ach lom-lár na
+“Ní haon mhagadh é,” ar seisean, “ach lomlár na
 fírinne.”
 
-D’éirigh an tríomhadh fear, do sheas taobh leis ag an
+D’éirigh an tríú fear, do sheas taobh leis ag an
 dteine agus d’fhéach idir an dá shúil air.
 
 “Réaltóir tusa,” ar seisean leis. “Tá níos mó
-eolais agat-sa ar na réalta agus ar na pláinéidí ná
-mar atá ag aon fhear eile beo. An é adeir tú linn go
+eolais agatsa ar na réalta agus ar na pláinéidí ná
+mar atá ag aon fhear eile beo. An é a deir tú linn go
 bhfuil an phláinéid seo ann, agus gur giorra dhúinn í ná
 aon phláinéid eile, ach mar sin féin nách féidir dúinn í
-fheiscint?”
+a fheiscint?”
 
 “Is mar sin atá,” arsa an réaltóir.
 
-“Má’s fíor bréag,” arsa Seán Ó Maolchatha, ach is
+“Más fíor bréag,” arsa Seán Ó Maolchatha, ach is
 
 [l.10]: #
-fé n-a anáil adubhairt sé é, agus ní chuala an bheirt eile é.
-Ba dhóig le duine, ámhthach, gur thuig an réaltóir an rud a
-bhí ina aigne, mar d’iompuigh sé chuige agus do labhair leis.
+féna anáil a dúirt sé é, agus ní chuala an bheirt eile é.
+Ba dhóigh le duine, áfach, gur thuig an réaltóir an rud a
+bhí ina aigne, mar d’iompaigh sé chuige agus do labhair leis.
 
-“Tá fhios agam ná creideann tú mé,” ar seisean.
+“Tá a fhios agam ná creideann tú mé,” ar seisean.
 
 “Nuair a chífead im’ shúilibh cinn féin an phláinéid sin
-ag lonnradh sa spéir san oidhche, creidfead go bhfuil sí
+ag lonradh sa spéir san oíche, creidfead go bhfuil sí
 ann,” arsa Seán.
 
-“D’fhéach an réaltóir air ar feadh nóimitín agus
+D’fhéach an réaltóir air ar feadh nóimitín agus
 iarracht d’fheirg air, ach annsan do chaith sé a cheann siar.
 Agus do chuir gáire as.
 
@@ -47,20 +47,20 @@ Agus do chuir gáire as.
 
 Bhí an fear eile ag féachaint go géar idir an dá shúil air.
 
-“A Mhichíl Uí Fhlaithimh,” ar seisean, “mar adubhairt
+“A Mhichíl Uí Fhlaithimh,” ar seisean, “mar adúirt
 mé cheana, is tú an réaltóir is fearr agus is mó cáil ar
-domhan. Má deir tú liom go bhfuil a leithéid de pláinéid
+domhan. Má deir tú liom go bhfuil a leithéid de phláinéid
 ann géillim duit go bhfuil sí ann, agus gan de dheimhniú
-agam ar fhírinne do scéil ach t’fhocal amháin. Ach fiafruighim 
+agam ar fhírinne do scéil ach t’fhocal amháin. Ach fiafraím
 an méid seo dhíot. Má tá an phláinéid sin ann
 cad ’na thaobh ná feictear í?”
 
 “Sin í an cheist,” arsa Seán Ó Maolchatha, agus do
-bhuail sé buille d’á bhais anuas ar a leath-ghlúin. “Má
+bhuail sé buille dá bhais anuas ar a leathghlúin. “Má
 tá sí ann cad ’na thaobh ná feictear í?”
 
 “Tá sí ann,” arsa an réaltóir, “agus ní feictear í.
-’Neosfad daoibh ché’n fáth.”
+Neosfad daoibh cén fáth.”
 
 [l.11]: #
 
@@ -68,221 +68,221 @@ Do shuidh sé sa chathaoir arís agus do bhain cúpla seach
 as a phíopa.
 
 “Ní feictear an phláinéid sin,” ar seisean, “toisc
-brat tiugh de gheas éigin an-aithnid a bheith timcheall uirthe,
-á ceilt. Sin é an fáth go bhfuil sí foluighthe ó shúilibh an
+brat tiugh de gheas éigin an-aithnid a bheith timpeall uirthi,
+á ceilt. Sin é an fáth go bhfuil sí folaithe ó shúilibh an
 chine daonna, agus sin é an fáth ná feictear sa spéir san
-oidhche í, mar a chítear na pláinéidí eile.”
+oíche í, mar a chítear na pláinéidí eile.”
 
-“Ach maran féidir í fheiscint cá bhfios duit í bheith
+“Ach maran féidir í a fheiscint cá bhfios duit í a bheith
 ann?” arsa Seán.
 
 “Scéal fada é sin,” arsa an réaltóir, “agus bainfidh
-sé tamall fada dhíom é innsint.”
+sé tamall fada dhíom é a insint.”
 
 I dtigh an réaltóra a bhí an triúr fear agus iad tar
-éis dinnéar a chaitheamh ann. Eiteallánuí clúmhail ab
-eadh Seán Ó Maolchatha. Bhí sé tugtha suas dó gurbh é
-an píolóid ba chliste agus ba neamh-eaglaighe d’á raibh
-ann le n-a linn. “Tá Dia buidheach de Sheán Ó Maolchatha,”
-adeireadh daoine. Agus ní raibh aon amhras ná go
-dtáinig sé slán as gach contabhairt d’á rug riamh air.
+éis dinnéar a chaitheamh ann. Eiteallánaí clúúil ab
+ea Seán Ó Maolchatha. Bhí sé tugtha suas dó gurbh é
+an píolóid ba chliste agus ba neamh-eaglaí dá raibh
+ann lena linn. “Tá Dia buíoch de Sheán Ó Maolchatha,”
+a deireadh daoine. Agus ní raibh aon amhras ná go
+dtáinig sé slán as gach contúirt dá rug riamh air.
 
-Ollamh san Ollscoil ab eadh an tarna fear agus
+Ollamh san Ollscoil ab ea an tarna fear agus
 Máirtín Mac Con Midhe ab ainm agus ba shloinne dhó.
 Bhí clú agus cáil air ar fuaid an domhain i gcúrsaí
-eoluidheachta.
+eolaíochta.
 
-Bhí an réaltóir ina shuidhe sa chathaoir agus é ag
-féachaint ar an mbeirt aca agus iarracht de mhagadh ina
+Bhí an réaltóir ina shuí sa chathaoir agus é ag
+féachaint ar an mbeirt acu agus iarracht de mhagadh ina
 shúilibh.
 
 [l.12]: #
 
-“Bhí cúis fé leith agam le cuaireadh a thabhairt do’n
-bheirt agaibh chun teacht annso anocht,” ar seisean.
-“Sé Seán Ó Maolchatha an t-eiteallánuí is fearr ar
+“Bhí cúis fé leith agam le cuireadh a thabhairt don
+bheirt agaibh chun teacht anso anocht,” ar seisean.
+“’S é Seán Ó Maolchatha an t-eiteallánuí is fearr ar
 domhan, agus tá tuiscint ag Máirtín Mac Con Midhe i
-gcúrsaí eoluidheachta thar mar atá ag aon fhear eile beo.
-Mar gheall ar na tréithe sin sa bheirt agaibh is eadh iarras
+gcúrsaí eolaíochta thar mar atá ag aon fhear eile beo.
+Mar gheall ar na tréithe sin sa bheirt agaibh is ea iarras
 oraibh teacht chun an tighe anocht.”
 
 D’fhéach an bheirt eile ar a chéile.
 
-“An as a mheabhair atá sé?” adubhairt a súile.
-Ní dubhairt a mbéal aon fhocal, ámhthach.
+“An as a mheabhair atá sé?” a dúirt a súile.
+Ní dúirt a mbéal aon fhocal, áfach.
 
-Is maith a thuig an réaltóir an rud a bhí ina n-aigne aca.
+Is maith a thuig an réaltóir an rud a bhí ina n-aigne acu.
 
 “Is dóigh libh gur as mo mheabhair atáim,” ar seisean,
-“ach bíodh foidhne agaibh. Agus léireochad daoibh ná fuil
-mire ná mearthall orm. Ní dhéanfad a thuille boghríní ar
-an scéal ach é innsint daoibh díreach fé mar atá.
+“ach bíodh foidhne agaibh. Agus léireod daoibh ná fuil
+mire ná mearathal orm. Ní dhéanfad a thuilleadh boghasíní ar
+an scéal ach é a insint daoibh díreach fé mar atá.
 
-“Deich mbliana ó shoin do chaitheas tamall san
-Éigipt ar mo laetheanta saoire. Thárla go raibh buidhean
-d’fhearaibh léigheanta an uair sin ag tomhach na bpluais
-agus na n-uaigh sa tír sin. Bhí aithne agam ar dhuine aca
-agus thug sé cuireadh dhom chun dul i n-éinfheacht leis ag
-feiscint na hoibre a bhí á dhéanamh aca. Is amhlaidh a
-bhíodar tar éis teacht ar uaigh dhuine de sheana-righthe na
+“Deich mbliana ó shin do chaitheas tamall san
+Éigipt ar mo laetheanta saoire. Tharla go raibh buíon
+d’fhearaibh léannta an uair sin ag tómhach na bpluais
+agus na n-uaigh sa tír sin. Bhí aithne agam ar dhuine acu
+agus thug sé cuireadh dhom chun dul in éineacht leis ag
+feiscint na hoibre a bhí á dhéanamh acu. Is amhlaidh a
+bhíodar tar éis teacht ar uaigh dhuine de sheana-ríthe na
 hÉigipte. Bhíodh cúntaisí ar na páipéir i dtaobh na
 huaighe san am, agus is dócha gur léigh an bheirt agaibh iad.”
 
-“Is cuimhin liom iad, arsa Máirtín. “Dubhairt
+“Is cuimhin liom iad, arsa Máirtín. “Dúirt
 
 [l.13]: #
-lucht na bpáipéar ná fuarathas oiread seod seanda i n-aon
+lucht na bpáipéar ná fuarathas oiread seod seanda in aon
 uaigh riamh agus a fuarathas san uaigh sin.”
 
 “Bhí an ceart ag lucht na bpáipéar,” arsa an
 réaltóir. “Ní beag de sheó a bhfuarathas d’árthaí agus
 de sheoda agus d’iarsmaí de gach aon tsaghas ins an uaigh
-sin. Agus fuarathas, leis, innte, mór-chuid pár, nó
-paipírí, agus scríbhinní doimhne do-léighte ortha. Bhí sé
-d’ádh orm-sa seilbh d’fháil ar cheann de sna paipírí sin.
-Is le duadh a fuaireas é, ach scéal eile é sin agus ní
-’neosfad daoibh anocht e.”
+sin. Agus fuarathas, leis, inti, mórchuid pár, nó
+paipírí, agus scríbhinní doimhne doléite orthu. Bhí sé
+d’ádh ormsa seilbh d’fháil ar cheann de sna paipírí sin.
+Is le dua a fuaireas é, ach scéal eile é sin agus ní
+neosfad daoibh anocht é.”
 
-D’fhéach an bheirt eile ar a chéile ach ní dubhradar
+D’fhéach an bheirt eile ar a chéile ach ní dúradar
 aon fhocal.
 
-“Téasbáinfead daoibh é. Tá fhios agam gur maith
+“Teaspáinfead daoibh é. Tá fhios agam gur maith
 le Seán Ó Maolchatha gach éinní a fheiscint ina shúilibh cinn
 féin.”
 
-Anonn leis do’n chomhrainn daingin a bhí i gcúinne
-de’n tseomra, agus do bhain an glas di. Bhí carn
+Anonn leis don chomhrainn daingin a bhí i gcúinne
+den tseomra, agus do bhain an glas di. Bhí carn
 páipéar sa chomhrainn. Do thóg sé na páipéir ina láimh agus
 do nocht bosca beag iarainn fútha. Do thóg sé an bosca
-as an gcomhrainn agus tháinig thar n-ais chun a’chathaoireach.
+as an gcomhrainn agus tháinig thar n-ais chun a chathaoireach.
 Bhain sé eochair bheag as a phóca agus d’oscail an bosca.
-Bhí seana-phár istigh ann. Do chróm an bheirt eile níos
-giorra dhó chun é fheiscint. Do thóg sé an pár as an
-mbosca agus do leathnuigh amach é.
+Bhí seana-phár istigh ann. Do chrom an bheirt eile níos
+giorra dhó chun é a fheiscint. Do thóg sé an pár as an
+mbosca agus do leathnaigh amach é.
 
 “Chíonn sibh cad tá ann,” ar seisean.
 
 [l.14]: #
 
-“Diabhal a bhfeadar-sa cad tá ann,” arsa Seán ó
-Maolchatha. “Ní fheicim-se ann ach píosa de sheana-phár
-dhuidhe agus é ag tuitim as a chéile leis an aois.”
+“Diabhal a bhfeadarsa cad tá ann,” arsa Seán ó
+Maolchatha. “Ní fheicimse ann ach píosa de sheana-phár
+bhuidhe agus é ag tuitim as a chéile leis an aois.”
 
-“Cairt nó léarscáil atá ann, arsa Máirtín.
+“Cairt nó léarscáil atá ann,” arsa Máirtín.
 
 “Tá an ceart agat,” arsa an réaltóir, “cairt nó
-léarscáil atá ann. Léarscáil de’n spéir atá ann.
+léarscáil atá ann. Léarscáil den spéir atá ann.
 Féach air sin, a Sheáin, agus air sin, agus air sin. Ná
-haithnigheann tú an Cam-Chéacht agus na réalta eile atá
-ar eolas agat? Gach aon cheann aca breacuithe síos chomh
+haithníonn tú an Cam-Chéacht agus na réalta eile atá
+ar eolas agat? Gach aon cheann acu breacaithe síos chomh
 cruinn beacht agus a dhéanfainn féin iad.”
 
-“Am’ briathar ach go bhfuil an ceart agat,” arsa Seán
-agus an dá shúil ag dul amach as a cheann le hiongantas
+“Im’ briathar ach go bhfuil an ceart agat,” arsa Seán
+agus an dá shúil ag dul amach as a cheann le hiontas
 an scéil.
 
 “Táid go léir ann go cruinn is go beacht,” arsa an
 réaltóir arís. “Ach tá rud ar an gcairt sin a chuir
-iongantas orm-sa an chéad uair a chonnac í. Tá pláinéid
-uirthe de breis ar na cinn atá ar eolas againne.”
+iontas ormsa an chéad uair a chonac í. Tá pláinéid
+uirthi de bhreis ar na cinn atá ar eolas againne.”
 
-“An ndeireann tú liom é?” arsa an t-eiteallánuí
-agus an’ dá shúil sáidhte sa chairt aige.
+“An ndeireann tú liom é?” arsa an t-eiteallánaí
+agus an dá shúil sáite sa chairt aige.
 
-“Dubhart liom féin i dtosach gur dócha gur dearmhad
-a bhí ar án té a dhein an chairt, ach do thuigeas ar a chruinne
-a bhí gach aon nidh breacuithe síos aige gurbh eoluidhe cliste
-oilte é, gurbh fhear é ná déanfadh dearmhad ach oiread is
-a dhéanfainn féin dearmhad, nó oiread is a dhéanfadh
-Seán dearmhad agus é i mbun aon nidh a bhaineann le
-n-a eiteallán.”
+“Dúrt liom féin i dtosach gur dócha gur dearúd
+a bhí ar an té a dhein an chairt, ach do thuigeas ar a chruinne
+a bhí gach aon ní breacaithe síos aige gurbh eolaí cliste
+oilte é, gurbh fhear é ná déanfadh dearúd ach oiread is
+a dhéanfainn féin dearúd, nó oiread is a dhéanfadh
+Seán dearúd agus é i mbun aon ní a bhaineann lena
+eiteallán.”
 
 [l.15]: #
 
-“Dá ndeininn-se dearmhad,” arsa Seán, “is daor a
+“Dá ndeininnse dearúd,” arsa Seán, “is daor a
 dhíolfainn as,” agus do chuir sé smuta gáire as.
 
 “Buaileadh isteach im’ aigne,” arsa an fear eile,
 “nách foláir nó bhí an phláinéid ann an uair sin. Ach má
-bhí sí ann an uair sin cadh ’na thaobh ná fuil sí ann anois?
-B’shin í an cheist. B’shin í an adhb a bhain codladh na
-hoidhche dhíom-sa ar feadh i bhfad. B’é toradh mo stuidéir
-agus toradh mo mhachtnaimh ar an gceist go rabhas deimhnigtheach 
+bhí sí ann an uair sin cad ’na thaobh ná fuil sí ann anois?
+B’in í an cheist. B’in í an fhadhb a bhain codladh na
+hoíche dhíomsa ar feadh i bhfad. B’é toradh mo stuidéir
+agus toradh mo mhachtnaimh ar an gceist go rabhas deimhneach
 de go raibh an phláinéid sa spéir san áit ina raibh
-sí breacuithe síos ag an sean-eolgach Éigipteach, ach ar chuma
-éigin nách féidir í fheiscint. Táim ag gabháil do’n cheist le
+sí breacaithe síos ag an sean-eolgach Éigipteach, ach ar chuma
+éigin nách féidir í a fheiscint. Táim ag gabháil don cheist le
 deich mbliana. Ní bhead bhúr mbodhradh le mion-chúntaisí ar
-an áireamh a dheineas ar chúrsaí na pláinéid, ná ar an méid
-saothair a dheineas ar ghloiní agus ar chiandhracáin. Ní
-déarfad ach an méid seo——gur éirigh liom sa deire ciandracán 
+an áireamh a dheineas ar chúrsaí na bpláinéid, ná ar an méid
+saothair a dheineas ar ghloiní agus ar chiandracáin. Ní
+déarfad ach an méid seo——gur éirigh liom sa deireadh ciandracán
 a dhéanamh a thugann radharc dom ar an bpláinéid
-sin atá foluighthe ó shúilibh an duine.”
+sin atá folaithe ó shúilibh an duine.”
 
-“Ach ní raibh ciandracán de’n tshórd san ag an sean-Éigipteach,”
+“Ach ní raibh ciandracán den tsord san ag an sean-Éigipteach,”
 arsa Seán, “agus nách maith go bhfeaca
 seisean í.”
 
-“Ní fheadar an bhfeaca sé í. Ach bhí fhios aige í bheith
-ann. Bhí fios aca súd ná tuigimíd-ne.”
+“Ní fheadar an bhfeaca sé í. Ach bhí fhios aige í a bheith
+ann. Bhí fios acu súd ná tuigimídne.”
 
-“Is iongantach an scéal é,” arsa Máirtín.
+“Is iontach an scéal é,” arsa Máirtín.
 
-“Tagaidh liom anois chun an tighe ina bhfuil na
-ciandracáin agus teasbáinfead daoibh an phláinéid ná
+“Tagaidh liom anois chun an tí ina bhfuil na
+ciandracáin agus teaspáinfead daoibh an phláinéid ná
 feaca duine ar bith riamh ach mé féin agus fir feasa na
 hÉigipte anallód, b’fhéidir.”
 
 [l.16]: #
 
-Leis sin do phreab garsún amach ó’n dtaobh thiar de’n
+Leis sin do phreab garsún amach ón dtaobh thiar den
 scáileán a bhí treasna ar an bhfuinneóig.
 
-“Ó, a dhaid,” ar seisean, “leig dom-sa í Feiscint."
+“Ó, a dhaid,” ar seisean, “leig domhsa í a fheiscint."
 
 Do baineadh geit as an mbeirt eile ach do leag an
-realtóir a lámh ar cheann an gharsúin agus do labhair go
+réaltóir a lámh ar cheann an gharsúin agus do labhair go
 cneasta leis.
 
 “Cheapas go raibh tusa id’ leabaidh fadó riamh, a mhic,”
-ar seisean. “Ná fuil fhios agat go bhfuil sé leath-uair
+ar seisean. “Ná fuil fhios agat go bhfuil sé leathuair
 tar éis a deich?”
 
 “Bhíos ag dul a chodladh,” arsa an garsún, “ach do
 sheasas sa bhfuinneóig ag féachaint ar na réilthíní. Is
-deas liom bheith ag féachaint ortha agus á n-aithniúint.”
+deas liom bheith ag féachaint orthu agus á n-aithniúint.”
 
 “Is dual athar duit suim a bheith agat ins na réilthíní,”
 arsa Seán Ó Maolchatha agus do gháir sé leis.
 
-“Bhí oiread san suime agam ionnta,” arsa an garsún,
-“gur shuidheas sa chathaoir taobh thiar de’n scáileán ag
-féachaint ortha gur thuit mo chodladh orm. Do ghlór-sa a
-dhúisigh me, a dhaid, agus tú ag innsint i dtaobh na pláinéide
+“Bhí oiread san suime agam ionta,” arsa an garsún,
+“gur shuíos sa chathaoir taobh thiar den scáileán ag
+féachaint orthu gur thuit mo chodladh orm. Do ghlórsa a
+dhúisigh me, a dhaid, agus tú ag insint i dtaobh na pláinéide
 nua. Leig leat mé go bhfeicead í.”
 
 “Ní haon phláinéid nua í,” arsa an t-athair. “Tá sí
-riamh ann, ach nárbh fhéidir í fheiscint go dtí so. Rith leat
-a chodladh agus teasbáinfead duit oidhche éigin eile í.
-Suas an staighre leat anois.” 
+riamh ann, ach nárbh fhéidir í a fheiscint go dtí so. Rith leat
+a chodladh agus teaspáinfead duit oíche éigin eile í.
+Suas an staighre leat anois.”
 
 Thug an garsún aghaidh ar a sheomra codlata ach ba
 léir gur i gcoinnibh a chos é.
 
 [l.17]: #
 
-“Oidhche mhaith dhuit, a mhic,” arsa an réaltóir leis.
+“Oíche mhaith dhuit, a mhic,” arsa an réaltóir leis.
 
-“Oidhche mhaith dhuit, a dhaid. Oidhche mhaith dhaoibh,
+“Oíche mhaith dhuit, a dhaid. Oíche mhaith dhaoibh,
 a dhaoine uaisle," ar seisean.
 
-“Is breágh an garsún é, bail ó Dhia air,” arsa
+“Is breá an garsún é, bail ó Dhia air,” arsa
 Máirtín, chomh luath agus a bhí sé as raon éisteachta.
 
-“Tá sé imthighthe ó smacht, is baoghalach,” arsa an
+“Tá sé imithe ó smacht, is baolach,” arsa an
 t-athair, “toisc ná fuil agam ach é, agus a mháthair bhocht a
 bheith san uaigh le seacht mbliana.”
 
-Agus do leig an réaltóir clúmhail osna cléibh, agus é
+Agus do leig an réaltóir clúúil osna cléibh, agus é
 ag seoladh na beirte eile an cúl-doras amach chun an
-tighe ar an dtaobh thall de’n gháirdín mar a raibh na
+tí ar an dtaobh thall den gháirdín mar a raibh na
 ciandracáin.

--- a/caibidlí/old-orthography/manannan00.md
+++ b/caibidlí/old-orthography/manannan00.md
@@ -34,13 +34,13 @@ Mí na Nodlag, 1939.
 
 |                                   |Leaṫanaċ.|
 | :---                                  | ---:|
-| Pláinéid ná Feaca Súil Duine Riaṁ     |   9 |
+| Pláinéid ná Feaca Súil Duine riaṁ     |   9 |
 | An Raḋarc tríd an gCiandracán         |  18 |
 | An Turas go Manannán                  |  31 |
 | Manannán                              |  44 |
 | Muintear Ṁanannáin                    |  53 |
 | Na ‘Cráiḋmí’                          |  68 |
-| An tárd-Ṁáiġistir                     |  76 |
+| An tÁrd-Ṁáiġistir                     |  76 |
 | An Príosún                            |  87 |
 | Oiḋċe sa Ċoill                        |  98 |
 | An tInneall                           | 110 |

--- a/caibidlí/old-orthography/manannan01.md
+++ b/caibidlí/old-orthography/manannan01.md
@@ -1,6 +1,6 @@
 [l.9]: #
 
-# Pláinéid ná Feaca Súil Duine Riaṁ
+# Pláinéid ná Feaca Súil Duine riaṁ
 
 Do ċaiṫ Seán Ó Maolċaṫa é féin siar sa ċaṫaoir
 agus do ċuir gáire as.
@@ -29,7 +29,7 @@ aon ṗláinéid eile, aċ mar sin féin náċ féidir dúinn í
 
 [l.10]: #
 fé n-a anáil aduḃairt sé é, agus ní ċuala an ḃeirt eile é.
-Ba ḋóig le duine, áṁṫaċ, gur ṫuig an réaltóir an rud a
+Ba ḋóiġ le duine, áṁṫaċ, gur ṫuig an réaltóir an rud a
 ḃí ina aigne, mar d’iompuiġ sé ċuige agus do laḃair leis.
 
 “Tá ḟios agam ná creideann tú mé,” ar seisean.
@@ -51,7 +51,7 @@ Agus do ċuir gáire as.
 mé ċeana, is tú an réaltóir is fearr agus is mó cáil ar
 doṁan. Má deir tú liom go ḃfuil a leiṫéid de pláinéid
 ann géillim duit go ḃfuil sí ann, agus gan de ḋeiṁniú
-agam ar ḟírinne do scéil aċ t’ḟocal aṁáin. Aċ fiafruiġim 
+agam ar ḟírinne do scéil aċ t’ḟocal aṁáin. Aċ fiafruiġim
 an méid seo ḋíot. Má tá an ṗláinéid sin ann
 cad ’na ṫaoḃ ná feictear í?”
 
@@ -60,7 +60,7 @@ cad ’na ṫaoḃ ná feictear í?”
 tá sí ann cad ’na ṫaoḃ ná feictear í?”
 
 “Tá sí ann,” arsa an réaltóir, “agus ní feictear í.
-’Neosfad daoiḃ ċé’n fáṫ.”
+’Neosfad daoiḃ cé’n fáṫ.”
 
 [l.11]: #
 
@@ -98,7 +98,7 @@ féaċaint ar an mbeirt aca agus iarraċt de ṁagaḋ ina
 
 [l.12]: #
 
-“Ḃí cúis fé leiṫ agam le cuaireaḋ a ṫaḃairt do’n
+“Ḃí cúis fé leiṫ agam le cuireaḋ a ṫaḃairt do’n
 ḃeirt agaiḃ ċun teaċt annso anoċt,” ar seisean.
 “Sé Seán Ó Maolċaṫa an t-eiteallánuí is fearr ar
 doṁan, agus tá tuiscint ag Máirtín Mac Con Miḋe i
@@ -115,7 +115,7 @@ Is maiṫ a ṫuig an réaltóir an rud a ḃí ina n-aigne aca.
 
 “Is dóiġ liḃ gur as mo ṁeaḃair atáim,” ar seisean,
 “aċ bíoḋ foiḋne agaiḃ. Agus léireoċad daoiḃ ná fuil
-mire ná mearṫall orm. Ní ḋéanfad a ṫuille boġríní ar
+mire ná mearṫall orm. Ní ḋéanfad a ṫuille boġsíní ar
 an scéal aċ é innsint daoiḃ díreaċ fé mar atá.
 
 “Deiċ mbliana ó ṡoin do ċaiṫeas tamall san
@@ -141,12 +141,12 @@ sin. Agus fuaraṫas, leis, innte, mór-ċuid pár, nó
 paipírí, agus scríḃinní doiṁne do-léiġte orṫa. Ḃí sé
 d’áḋ orm-sa seilḃ d’ḟáil ar ċeann de sna paipírí sin.
 Is le duaḋ a fuaireas é, aċ scéal eile é sin agus ní
-’neosfad daoiḃ anoċt e.”
+’neosfad daoiḃ anoċt é.”
 
 D’ḟéaċ an ḃeirt eile ar a ċéile aċ ní duḃradar
 aon ḟocal.
 
-“Téasbáinfead daoiḃ é. Tá ḟios agam gur maiṫ
+“Teasbáinfead daoiḃ é. Tá ḟios agam gur maiṫ
 le Seán Ó Maolċaṫa gaċ éinní a ḟeiscint ina ṡúiliḃ cinn
 féin.”
 
@@ -154,9 +154,9 @@ Anonn leis do’n ċoṁrainn daingin a ḃí i gcúinne
 de’n tseomra, agus do ḃain an glas di. Ḃí carn
 páipéar sa ċoṁrainn. Do ṫóg sé na páipéir ina láiṁ agus
 do noċt bosca beag iarainn fúṫa. Do ṫóg sé an bosca
-as an gcoṁrainn agus ṫáinig ṫar n-ais ċun a’ċaṫaoireaċ.
+as an gcoṁrainn agus ṫáinig ṫar n-ais ċun a ċaṫaoireaċ.
 Ḃain sé eoċair ḃeag as a ṗóca agus d’oscail an bosca.
-Ḃí seana-ṗár istiġ ann. Do ċróm an ḃeirt eile níos
+Ḃí seana-ṗár istiġ ann. Do ċrom an ḃeirt eile níos
 giorra ḋó ċun é ḟeiscint. Do ṫóg sé an pár as an
 mbosca agus do leaṫnuiġ amaċ é.
 
@@ -164,11 +164,11 @@ mbosca agus do leaṫnuiġ amaċ é.
 
 [l.14]: #
 
-“Diaḃal a ḃfeadar-sa cad tá ann,” arsa Seán ó
+“Diaḃal a ḃfeadar-sa cad tá ann,” arsa Seán Ó
 Maolċaṫa. “Ní ḟeicim-se ann aċ píosa de ṡeana-ṗár
-ḋuiḋe agus é ag tuitim as a ċéile leis an aois.”
+ḃuiḋe agus é ag tuitim as a ċéile leis an aois.”
 
-“Cairt nó léarscáil atá ann, arsa Máirtín.
+“Cairt nó léarscáil atá ann,” arsa Máirtín.
 
 “Tá an ceart agat,” arsa an réaltóir, “cairt nó
 léarscáil atá ann. Léarscáil de’n spéir atá ann.
@@ -184,13 +184,13 @@ an scéil.
 “Táid go léir ann go cruinn is go beaċt,” arsa an
 réaltóir arís. “Aċ tá rud ar an gcairt sin a ċuir
 iongantas orm-sa an ċéad uair a ċonnac í. Tá pláinéid
-uirṫe de breis ar na cinn atá ar eolas againne.”
+uirṫe de ḃreis ar na cinn atá ar eolas againne.”
 
 “An ndeireann tú liom é?” arsa an t-eiteallánuí
-agus an’ dá ṡúil sáiḋte sa ċairt aige.
+agus an dá ṡúil sáiḋte sa ċairt aige.
 
 “Duḃart liom féin i dtosaċ gur dóċa gur dearṁad
-a ḃí ar án té a ḋein an ċairt, aċ do ṫuigeas ar a ċruinne
+a ḃí ar an té a ḋein an ċairt, aċ do ṫuigeas ar a ċruinne
 a ḃí gaċ aon niḋ breacuiṫe síos aige gurḃ eoluiḋe cliste
 oilte é, gurḃ ḟear é ná déanfaḋ dearṁad aċ oiread is
 a ḋéanfainn féin dearṁad, nó oiread is a ḋéanfaḋ
@@ -207,18 +207,18 @@ n-a eiteallán.”
 ḃí sí ann an uair sin caḋ ’na ṫaoḃ ná fuil sí ann anois?
 B’ṡin í an ċeist. B’ṡin í an aḋb a ḃain codlaḋ na
 hoiḋċe ḋíom-sa ar feaḋ i ḃfad. B’é toraḋ mo stuidéir
-agus toraḋ mo ṁaċtnaiṁ ar an gceist go raḃas deiṁnigṫeaċ 
+agus toraḋ mo ṁaċtnaiṁ ar an gceist go raḃas deiṁnigṫeaċ
 de go raiḃ an ṗláinéid sa spéir san áit ina raiḃ
 sí breacuiṫe síos ag an sean-eolgaċ Éigipteaċ, aċ ar ċuma
 éigin náċ féidir í ḟeiscint. Táim ag gaḃáil do’n ċeist le
 deiċ mbliana. Ní ḃead ḃúr mboḋraḋ le mion-ċúntaisí ar
-an áireaṁ a ḋeineas ar ċúrsaí na pláinéid, ná ar an méid
-saoṫair a ḋeineas ar ġloiní agus ar ċianḋracáin. Ní
-déarfad aċ an méid seo——gur éiriġ liom sa deire ciandracán 
+an áireaṁ a ḋeineas ar ċúrsaí na bpláinéid, ná ar an méid
+saoṫair a ḋeineas ar ġloiní agus ar ċiandracáin. Ní
+déarfad aċ an méid seo——gur éiriġ liom sa deire ciandracán
 a ḋéanaṁ a ṫugann raḋarc dom ar an bpláinéid
 sin atá foluiġṫe ó ṡúiliḃ an duine.”
 
-“Aċ ní raiḃ ciandracán de’n tṡórd san ag an sean-Éigipteaċ,”
+“Aċ ní raiḃ ciandracán de’n tsórd san ag an sean-Éigipteaċ,”
 arsa Seán, “agus náċ maiṫ go ḃfeaca
 seisean í.”
 
@@ -237,10 +237,10 @@ hÉigipte anallód, b’ḟéidir.”
 Leis sin do ṗreab garsún amaċ ó’n dtaoḃ ṫiar de’n
 scáileán a ḃí treasna ar an ḃfuinneóig.
 
-“Ó, a ḋaid,” ar seisean, “leig dom-sa í Feiscint."
+“Ó, a ḋaid,” ar seisean, “leig doṁ-sa í ḟeiscint."
 
 Do baineaḋ geit as an mbeirt eile aċ do leag an
-realtóir a láṁ ar ċeann an ġarsúin agus do laḃair go
+réaltóir a láṁ ar ċeann an ġarsúin agus do laḃair go
 cneasta leis.
 
 “Ċeapas go raiḃ tusa id’ leabaiḋ fadó riaṁ, a ṁic,”
@@ -263,7 +263,7 @@ nua. Leig leat mé go ḃfeicead í.”
 “Ní haon ṗláinéid nua í,” arsa an t-aṫair. “Tá sí
 riaṁ ann, aċ nárḃ ḟéidir í ḟeiscint go dtí so. Riṫ leat
 a ċodlaḋ agus teasbáinfead duit oiḋċe éigin eile í.
-Suas an staiġre leat anois.” 
+Suas an staiġre leat anois.”
 
 Ṫug an garsún aġaiḋ ar a ṡeomra codlata aċ ba
 léir gur i gcoinniḃ a ċos é.


### PR DESCRIPTION
Hi, I went through the first chapter in both the old-orthography and new-orthography directories.

I think caught most of the typos in the first one and brought them to align with the PDF.

I also went into the `new-orthography` directory and started modernization of the spelling – but now I realize you started doing that in the `spelling` directory instead. I’m keeping the commit now so you can look at it.

Let me know what you want me to do with it (if anything) – I can drop it, move my changes to the `spelling` dir, or make another one.

There are some words like *suidh*, *foidhne*, *tiugh* which in the standard would be *suigh, foighne, tiubh* – I left them as spelt in the original – as those forms are etymologically more correct. But changing the first two to *suigh* and *foighne* would have no bearing on the text; I’m not sure about *tiugh* → *tiubh*, that potentially changes the pronunciation (and I’m not familiar enough with the author’s dialect to know whether *tiugh* is just a conservative spelling here or reflects the actual pronunciation).